### PR TITLE
KoboldAI parameter fix

### DIFF
--- a/Models/KoboldAI/KoboldAiRequestParams.cs
+++ b/Models/KoboldAI/KoboldAiRequestParams.cs
@@ -10,7 +10,7 @@
         public required float RepetitionPenaltySlope { get; set; }
         public required float TopP { get; set; }
         public required float TopA { get; set; }
-        public required float TopK { get; set; }
+        public required int TopK { get; set; }
         public required float TypicalSampling { get; set; }
         public required float TailFreeSampling { get; set; }
         public required bool SingleLine { get; set; }


### PR DESCRIPTION
Currently, Character Engine is passing all sampling parameters as `float,` but KoboldAI expects an `int` for  `TopK` (see #18)
This fix allows for very basic KoboldAI support, albeit without e.g. parameter adjustment which obviously still needs implementing.